### PR TITLE
extsnap: fix bug when -exton isn't set

### DIFF
--- a/monitor.c
+++ b/monitor.c
@@ -119,6 +119,10 @@
  *
  */
 
+#ifdef CONFIG_EXTSNAP
+extern bool exton;
+#endif
+
 typedef struct mon_cmd_t {
     const char *name;
     const char *args_type;
@@ -1858,6 +1862,10 @@ static void hmp_loadvm(Monitor *mon, const QDict *qdict)
 static void hmp_loadvm_ext(Monitor *mon, const QDict *qdict)
 {
     const char *name = qdict_get_str(qdict, "name");
+    if (exton == false) {
+	monitor_printf(mon, "Error: external snapshot subsystem was disabled\n");
+        return;
+    }
     if(incremental_load_vmstate_ext(name, mon) < 0) {
 	monitor_printf(mon, "Error: can't load the snapshot with args: %s\n", name);
     }
@@ -1866,6 +1874,10 @@ static void hmp_loadvm_ext(Monitor *mon, const QDict *qdict)
 static void hmp_savevm_ext(Monitor *mon, const QDict *qdict)
 {
     const char *name = qdict_get_str(qdict, "name");
+    if (exton == false) {
+	monitor_printf(mon, "Error: external snapshot subsystem was disabled\n");
+        return;
+    }
     save_vmstate_ext(mon, name);
 }
 #endif

--- a/vl.c
+++ b/vl.c
@@ -51,8 +51,9 @@ bool multinode_in_use;
 extern int64_t quantum_value, quantum_record_value, quantum_node_value;
 #endif
 
-
-
+#ifdef CONFIG_EXTSNAP
+    bool exton = false;
+#endif
 
 #ifdef CONFIG_SDL
 #if defined(__APPLE__) || defined(main)
@@ -3062,7 +3063,6 @@ int main(int argc, char **argv, char **envp)
     Error *err = NULL;
     bool list_data_dirs = false;
 #ifdef CONFIG_EXTSNAP
-    bool exton = false;
     const char* loadext = NULL;
 #endif
     typedef struct BlockdevOptions_queue {


### PR DESCRIPTION
declare exton flag as global and check it in savevm-ext and loadvm-ext

Signed-off-by: Klim Kireev <klim.kireev@epfl.ch>